### PR TITLE
Updates datatable styles to match yui and fixes sidebar scrolling.

### DIFF
--- a/sqlshare/static/styles/datatable.css
+++ b/sqlshare/static/styles/datatable.css
@@ -147,11 +147,13 @@ table.display {
      * If you want that effect I'd suggest setting a border-top/left on th/td's and 
      * then filling in the gaps with other borders.
      */
+     
+     border: solid 1px #7f7f7f;
 }
 
 table.display thead th {
-    padding: 3px 18px 3px 10px;
-    border-bottom: 1px solid black;
+    padding: 5px 10px;
+    border-bottom: 1px solid #7f7f7f;
     font-weight: bold;
     cursor: pointer;
     * cursor: hand;
@@ -168,13 +170,17 @@ table.display tr.heading2 td {
 }
 
 table.display td {
-    padding: 3px 10px;
+    padding: 5px 10px;
+    /*border-bottom: solid 1px #cbcbcb;*/
 }
 
 table.display td.center {
     text-align: center;
 }
 
+table.display tr:last-child td{
+    border: none;
+}
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -182,15 +188,15 @@ table.display td.center {
  */
 
 .sorting_asc {
-    background: url('../images/sort_asc.png') no-repeat center right;
+    background: #ddd url('../images/sort_asc.png') no-repeat center right;
 }
 
 .sorting_desc {
-    background: url('../images/sort_desc.png') no-repeat center right;
+    background: #ddd url('../images/sort_desc.png') no-repeat center right;
 }
 
 .sorting {
-    background: url('../images/sort_both.png') no-repeat center right;
+    background: #eee url('../images/sort_both.png') no-repeat center right;
 }
 
 .sorting_asc_disabled {
@@ -246,11 +252,11 @@ table.display tr.even.gradeU {
 
 
 tr.odd {
-    background-color: #E2E4FF;
+    background-color: #fff;
 }
 
 tr.even {
-    background-color: white;
+    background-color: #edf5ff;
 }
 
 
@@ -365,6 +371,8 @@ table.display tr.odd.row_selected td {
  * Sorting classes for columns
  */
 /* For the standard odd/even */
+
+/*
 tr.odd td.sorting_1 {
     background-color: #D3D6FF;
 }
@@ -388,7 +396,7 @@ tr.even td.sorting_2 {
 tr.even td.sorting_3 {
     background-color: #F9F9FF;
 }
-
+*/
 
 /* For the Conditional-CSS grading rows */
 /*

--- a/sqlshare/static/styles/sqlshare.css
+++ b/sqlshare/static/styles/sqlshare.css
@@ -23,7 +23,7 @@ top: 10px;
 
 /* Minimum Browser Width 1100px;  */
 
-body { min-width: 1100px; overflow-x: auto !important; }
+body { min-width: 1100px; overflow-x: hidden !important; }
 #ss_content, #ss_application_wrapper { min-width: 952px !important; }
 #ss_app_workspace { min-width: 395px; }
 
@@ -76,7 +76,7 @@ div.hr hr {
 
 /* Sidebar */
 .ss-sidebar { width: 148px; float: left; background-color: #d2d2d2; }
-.ss-sidebar-content { border-right:solid 1px #b0b0b0; padding-top: 8px; }
+.ss-sidebar-content { border-right:solid 1px #b0b0b0; padding-top: 8px; overflow-y: auto; }
 
 h3.ss-sidebar-logo { background-color: #316b92; height:41px; color: #fff;text-align:center; border-right: solid 1px #275877; margin:0; }
 h3.ss-sidebar-logo img { margin-top:10px; }
@@ -119,7 +119,7 @@ h3.ss-sidebar-logo img { margin-top:10px; }
 
 .ss-processing-container { position: absolute; left: 50%; top: 50%; margin-left: -40px;  margin-top: -40px; }
 
-.ss-content-header { line-height:30px; }
+.ss-content-header { }
 .ss-content-header p { margin: 0; }
 .ss-content-header h5 { color: #B0B0B0; font-size: 83%; display: inline; }
 .ss-content-header a, .ss-content-header a:visited { color: #888; text-decoration: none; }
@@ -239,22 +239,6 @@ border-top-right-radius: 4px;
 .ss-dataset-list .ss-access-shared-owner { display: inline-block; width: 20px; background: url(../images/ss-privacy.gif) no-repeat -16px 0; height: 16px; overflow: hidden; text-indent: 100px; vertical-align: middle; } */
 
 .ss-dataset-list .ss-access-shared-owner, .ss-dataset-list .ss-access-shared-viewer, .ss-dataset-list .ss-access-private { display: inline-block; width: 20px; background: url(../images/ss-privacy.gif) no-repeat -16px -32px; height: 16px; overflow: hidden; text-indent: 100px; vertical-align: middle; } 	 
-
-/* YUI Dataset List overrides */ 	 
-.yui-skin-sam .ss-dataset-list tr.yui-dt-odd { background-color: #fff; } 	 
-.yui-skin-sam .ss-dataset-list td { border: none; border-bottom: 1px solid #cbcbcb; } 	 
-.yui-skin-sam .ss-dataset-list th { border-right: none !important; } 	 
-
-.yui-skin-sam .ss-dataset-list tr.yui-dt-odd td.yui-dt-asc, 	 
-.yui-skin-sam .ss-dataset-list tr.yui-dt-odd td.yui-dt-desc, 	 
-.yui-skin-sam .ss-dataset-list tr.yui-dt-even td.yui-dt-asc, 	 
-.yui-skin-sam .ss-dataset-list tr.yui-dt-even td.yui-dt-desc { background-color: #fff; }
-
-.yui-skin-sam .ss-dataset-list tr.yui-dt-highlighted, 
-.yui-skin-sam .ss-dataset-list tr.yui-dt-highlighted td.yui-dt-asc, 
-.yui-skin-sam .ss-dataset-list tr.yui-dt-highlighted td.yui-dt-desc, 
-.yui-skin-sam .ss-dataset-list tr.yui-dt-even td.yui-dt-highlighted, 
-.yui-skin-sam .ss-dataset-list tr.yui-dt-odd td.yui-dt-highlighted { background-color: #fff; }
 
 /* Dataset Output Tables */
 

--- a/sqlshare/static/styles/tagging.css
+++ b/sqlshare/static/styles/tagging.css
@@ -48,7 +48,7 @@ margin-bottom: 3px;
     }
 
 
-#ss_app_workspace_table .ss-dataset-tags { margin-top: 4px; }
+#ss_app_workspace_table .ss-dataset-tags { margin-top: 4px; line-height: 1.5em; }
 
 .ss-dataset-tags { margin-top: 1em; }
 


### PR DESCRIPTION
I went ahead and update some styling to match the datatable look of YUI. I also removed some old yui specific styles that we were overriding. Sidebar was annoying me when the height would bump the entire page down. I went ahead and "froze" the body by not allowing overflow. scrolling should only happen within the sidebar or the main content area.
